### PR TITLE
Set `PrivateAssets="all"` on all dependencies

### DIFF
--- a/TerminalApi/TerminalApi.csproj
+++ b/TerminalApi/TerminalApi.csproj
@@ -49,8 +49,8 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">


### PR DESCRIPTION
This prevents your dependencies being auto-installed to anyone that installs the TerminalApi NuGet package.